### PR TITLE
Updating Link to syntax to support relative links

### DIFF
--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -53,7 +53,7 @@ class BlogIndex extends React.Component {
           }}
         >
           {!isFirst && (
-            <Link to={prevPage} rel="prev">
+            <Link to={`../${prevPage}`} rel="prev">
               ← Previous Page
             </Link>
           )}
@@ -78,7 +78,7 @@ class BlogIndex extends React.Component {
             </li>
           ))}
           {!isLast && (
-            <Link to={nextPage} rel="next">
+            <Link to={`../${nextPage}`} rel="next">
               Next Page →
             </Link>
           )}


### PR DESCRIPTION
Updating Link to syntax to support relative linking. This avoids the generated "Previous Page" and "Next Page" links from amending an additional directory to the existing URL. (E.g. with 3 or pages of posts, the "Next Page" link on page 2 should not link to /2/3/. It should link to /3/ instead.)